### PR TITLE
moved connection string to appsettings.Development.json 

### DIFF
--- a/JeopardyWebAPI/JeopardyWebAPI/JeopardyWebAPI.csproj.user
+++ b/JeopardyWebAPI/JeopardyWebAPI/JeopardyWebAPI.csproj.user
@@ -11,6 +11,7 @@
     <WebStackScaffolding_IsAsyncSelected>False</WebStackScaffolding_IsAsyncSelected>
     <NameOfLastUsedPublishProfile>FrenchJeopardyApi - Web Deploy</NameOfLastUsedPublishProfile>
     <ActiveDebugProfile>IIS Express</ActiveDebugProfile>
+    <ShowAllFiles>true</ShowAllFiles>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>

--- a/JeopardyWebAPI/JeopardyWebAPI/appsettings.Development.json
+++ b/JeopardyWebAPI/JeopardyWebAPI/appsettings.Development.json
@@ -5,5 +5,9 @@
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
     }
+  },
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "FeltGameContext": "server=feltgame.mariadb.database.azure.com;port=3306;user=mariadbadmin@feltgame;password=azuremariaDb!2020;database=feltgame;"
   }
 }

--- a/JeopardyWebAPI/JeopardyWebAPI/appsettings.json
+++ b/JeopardyWebAPI/JeopardyWebAPI/appsettings.json
@@ -5,9 +5,5 @@
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
     }
-  },
-  "AllowedHosts": "*",
-  "ConnectionStrings": {
-    "FeltGameContext": "server=feltgame.mariadb.database.azure.com;port=3306;user=mariadbadmin@feltgame;password=azuremariaDb!2020;database=feltgame;"
-  }
+  }  
 }


### PR DESCRIPTION
When building/running in development environment, application will use this file to load the connection string. File should be stored locally and not in GitHub. 
(Not required for production - set in App Service configuration)

More info: 
- https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-3.1
- http://docs.microsoft.com/en-us/aspnet/identity/overview/features-api/best-practices-for-deploying-passwords-and-other-sensitive-data-to-aspnet-and-azure